### PR TITLE
Add RWD for footer

### DIFF
--- a/src/components/layout/Footer/Footer.js
+++ b/src/components/layout/Footer/Footer.js
@@ -16,9 +16,9 @@ const Footer = ({ children }) => (
   <footer className={styles.root}>
     <div className={styles.footerMenu}>
       <div className='container'>
-        <div className='row'>
+        <div className={`row ${styles.mobileContainer}`}>
           <div className='col'>
-            <div className={styles.menuWrapper}>
+            <div className={`info ${styles.menuWrapper}`}>
               <h6>Information</h6>
               <ul>
                 <li>
@@ -37,7 +37,7 @@ const Footer = ({ children }) => (
             </div>
           </div>
           <div className='col'>
-            <div className={styles.menuWrapper}>
+            <div className={`account ${styles.menuWrapper}`}>
               <h6>My account</h6>
               <ul>
                 <li>
@@ -56,7 +56,7 @@ const Footer = ({ children }) => (
             </div>
           </div>
           <div className='col'>
-            <div className={styles.menuWrapper}>
+            <div className={`infoProduct ${styles.menuWrapper}`}>
               <h6>Information</h6>
               <ul>
                 <li>
@@ -75,7 +75,7 @@ const Footer = ({ children }) => (
             </div>
           </div>
           <div className='col'>
-            <div className={styles.menuWrapper}>
+            <div className={`orders ${styles.menuWrapper}`}>
               <h6>Orders</h6>
               <ul>
                 <li>
@@ -92,6 +92,11 @@ const Footer = ({ children }) => (
                 </li>
               </ul>
             </div>
+          </div>
+        </div>
+        <div className='row'>
+          <div className='col-lg-9'></div>
+          <div className='col col-lg-3 text-center'>
             <img src='./images/cards.png' alt='Supported credit cards' />
           </div>
         </div>
@@ -100,8 +105,8 @@ const Footer = ({ children }) => (
     <div className={styles.bottomBar}>
       <div className='container'>
         <div className='row align-items-center'>
-          <div className='col'></div>
-          <div className={'col text-center ' + styles.copyright}>
+          <div className='col-12 text-center'></div>
+          <div className={'col ' + styles.copyright}>
             <p>©Copyright 2016 Bazar | All Rights Reserved</p>
           </div>
           <div className={'col text-right ' + styles.socialMedia}>

--- a/src/components/layout/Footer/Footer.js
+++ b/src/components/layout/Footer/Footer.js
@@ -110,7 +110,7 @@ const Footer = ({ children }) => (
             <p>©Copyright 2016 Bazar | All Rights Reserved</p>
           </div>
           <div className={'col text-right ' + styles.socialMedia}>
-            <ul>
+            <ul className={styles.socialIcon}>
               <li>
                 <a href='#'>
                   <FontAwesomeIcon icon={faTwitter}>Twitter</FontAwesomeIcon>

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -49,6 +49,8 @@
     }
 
     .copyright {
+      text-align: center;
+
       p {
         margin: 0;
         color: $footer-copyright;
@@ -76,6 +78,43 @@
             }
           }
         }
+      }
+    }
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .root {
+    .mobileContainer {
+      display: grid;
+      align-items: start;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr 1fr;
+      grid-template-areas:
+        "a b"
+        "c d"
+      ;
+
+      .info {
+        grid-area: a;
+      }
+
+      .account {
+        grid-area: b;
+      }
+
+      .infoProduct {
+        grid-area: c;
+      }
+
+      .orders {
+        grid-area: d;
+      }
+    }
+
+    .bottomBar {
+      .copyright {
+        text-align: left;
       }
     }
   }

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -119,3 +119,22 @@
     }
   }
 }
+
+@media only screen and (max-width: 450px) {
+  .root {
+    .socialMedia {
+      margin-right: 0;
+    }
+  
+    .socialIcon { 
+      display: grid;
+      grid-template-columns: repeat(3, 30px);
+      float: right;
+
+      li {
+        justify-self: end;
+      }
+    }  
+  }
+}
+  


### PR DESCRIPTION
Problem: Brak RWD dla stopki, wymagania na małych urządzeniach po 2 kolumny, na większych 4. Copyright na małych urządzeniach do lewej, Socjalki do prawej.

Rozwiązanie: Ostylowanie pod wymagania klienta, zmieniłem także sposób wyświetlania płatności, gdyż na tabletach jego część była niewidoczna.

Ps. Osobiście ustawiłbym socjalki nad copyright, lepiej by to wyglądało na mobile.